### PR TITLE
Tab only preset

### DIFF
--- a/lua/tabby/presets.lua
+++ b/lua/tabby/presets.lua
@@ -213,6 +213,7 @@ local presets = {
 		},
 		active_tab = {
 			label = function(tabid)
+				local tabnum = vim.api.nvim_tabpage_get_number(tabid)
 				local focus = vim.api.nvim_tabpage_get_win(tabid)
 				local focus_name = filename.unique(focus)
 				if vim.api.nvim_win_get_config(focus).relative ~= "" then
@@ -225,7 +226,7 @@ local presets = {
 					append = " [" .. length .. "+]"
 				end
 				return {
-					"  " .. focus_name .. append .. " ",
+					" " .. tabnum .. " / " .. focus_name .. append .. " ",
 					hl = { fg = hl_tabline_sel.fg, bg = hl_tabline_sel.bg, style = "bold" },
 				}
 			end,
@@ -234,6 +235,7 @@ local presets = {
 		},
 		inactive_tab = {
 			label = function(tabid)
+				local tabnum = vim.api.nvim_tabpage_get_number(tabid)
 				local focus = vim.api.nvim_tabpage_get_win(tabid)
 				local focus_name = filename.unique(focus)
 				if vim.api.nvim_win_get_config(focus).relative ~= "" then
@@ -246,16 +248,12 @@ local presets = {
 					append = " [" .. length .. "+]"
 				end
 				return {
-					"  " .. focus_name .. append .. " ",
+					" " .. tabnum .. " / " .. focus_name .. append .. " ",
 					hl = { fg = hl_tabline.fg, bg = hl_tabline.bg, style = "bold" },
 				}
 			end,
 			left_sep = { "", hl = { fg = hl_tabline.bg, bg = hl_tabline_fill.bg } },
 			right_sep = { "", hl = { fg = hl_tabline.bg, bg = hl_tabline_fill.bg } },
-		},
-		tail = {
-			{ "", hl = { fg = hl_tabline.bg, bg = hl_tabline_fill.bg } },
-			{ "  ", hl = { fg = hl_tabline.fg, bg = hl_tabline.bg } },
 		},
 	},
 }

--- a/lua/tabby/tabline.lua
+++ b/lua/tabby/tabline.lua
@@ -25,6 +25,7 @@ local tabline = {}
 ---| "active_wins_at_end" # windows in active tab will be display at end of all tab labels
 ---| "tab_with_top_win"  # the top window display after each tab.
 ---| "active_tab_with_wins" # windows label follow active tab
+---| "tab_only" # no windows label, only tab
 
 ---@class TabbyWinLabelOpt
 ---@field label string|TabbyText|fun(winid:number):TabbyText


### PR DESCRIPTION
Add a preset which has no windows list. Show focused window's name and the number of windows.

![image](https://user-images.githubusercontent.com/9823531/136209912-fc325e30-484f-46b9-a358-b3db3a3c3ec9.png)