### PR TITLE
feat(mappings): Add `focus_visual_tab` mapping

### DIFF
--- a/lua/tabby/mappings.lua
+++ b/lua/tabby/mappings.lua
@@ -1,0 +1,16 @@
+local mappings = {}
+
+--- Focus tab based on the visual position of the tab in the tabline.
+--- The order of the list is from left to right with a the start as 1.
+--- If number is beyond the bounds of the tabpages it will do nothing.
+---@param n number visual tab number to focus
+function mappings.focus_visual_tab(n)
+	local list = vim.api.nvim_list_tabpages()
+	if n > #list then
+		return
+	end
+
+	vim.api.nvim_set_current_tabpage(list[n])
+end
+
+return mappings


### PR DESCRIPTION
`focus_visual_tab` is a useful keymapping helper function that selects a
tab based on the its location visually in the tabline. This is useful
when tabs are moved around. The tab id's or count's might not be in the
correct order. This function helps to create a mapping that will select
the tab based on its place on the tabline.

Example mappings:

nnoremap <leader>1 :lua require("tabby.mappings.").focus_visual_tab(1)<cr>
nnoremap <leader>2 :lua require("tabby.mappings.").focus_visual_tab(2)<cr>
nnoremap <leader>3 :lua require("tabby.mappings.").focus_visual_tab(3)<cr>
nnoremap <leader>4 :lua require("tabby.mappings.").focus_visual_tab(4)<cr>
...

Reference: #9 