### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ help of lua-language-server.
 ### Rename tab
 
 Use command `TabRename <tabname>` to rename tab. At all preset configs, it will work automatically.
-In your customize config, you can use `require('tabby.tabname).get(tabid)` to get tabname.
+In your customize config, you can use `require('tabby.tabname').get(tabid)` to get tabname.
 If no name is specified, it will display the focus window's Unique name.
 
 ## Quick start


### PR DESCRIPTION
```diff
- In your customize config, you can use `require('tabby.tabname).get(tabid)` to get tabname.
+ In your customize config, you can use `require('tabby.tabname').get(tabid)` to get tabname.
```