### PR TITLE
Fix `setup()`

### DIFF
--- a/lua/tabby/init.lua
+++ b/lua/tabby/init.lua
@@ -11,7 +11,7 @@ local tabby_opt = nil
 
 ---@param cfg? TabbyConfig
 function tabby.setup(cfg)
-  tabby_opt = vim.tbl_extend('force', config.defaults, cfg)
+  tabby_opt = vim.tbl_extend('force', config.defaults, cfg or {})
 
   vim.cmd([[
   augroup tabby_show_control


### PR DESCRIPTION
This patch tries to fix errors when call setup with no args (Like in readme.)

![image](https://user-images.githubusercontent.com/9823531/170978206-5441606f-92c0-48ef-bea5-5cf251ff558e.png)