### PR TITLE
Added Default Icon to win.file_icon function

### DIFF
--- a/lua/tabby/feature/tabwins.lua
+++ b/lua/tabby/feature/tabwins.lua
@@ -49,31 +49,13 @@ function tabwins.new_tab(tabid, opt)
       end
     end,
     is_modified = function()
-        wins = api.get_tab_wins(tabid)
-        for _, win in pairs(wins) do
-            if vim.bo[vim.api.nvim_win_get_buf(win)].modified then
-                return true
-            end
+      wins = api.get_tab_wins(tabid)
+      for _, win in pairs(wins) do
+        if vim.bo[vim.api.nvim_win_get_buf(win)].modified then
+          return true
         end
-        return false
-    end,
-        is_modified = function()
-        wins = api.get_tab_wins(tabid)
-        for i, x in pairs(wins) do
-            if vim.bo[vim.api.nvim_win_get_buf(x)].modified then
-                return true
-            end
-        end
-        return false
-    end,
-    is_modified = function()
-        wins = api.get_tab_wins(tabid)
-        for i, x in pairs(wins) do
-            if vim.bo[vim.api.nvim_win_get_buf(x)].modified then
-                return true
-            end
-        end
-        return false
+      end
+      return false
     end,
   }
 end
@@ -150,7 +132,7 @@ function tabwins.new_win(winid, opt)
       return require('tabby.feature.buf_name').get(winid, opt.buf_name)
     end,
     is_modified = function()
-      return vim.bo[buf.id].modified 
+      return vim.bo[tabwins.new_buf(api.get_win_buf(winid)).id].modified 
     end
   }
 end

--- a/lua/tabby/feature/tabwins.lua
+++ b/lua/tabby/feature/tabwins.lua
@@ -48,6 +48,33 @@ function tabwins.new_tab(tabid, opt)
         return ''
       end
     end,
+    is_modified = function()
+        wins = api.get_tab_wins(tabid)
+        for _, win in pairs(wins) do
+            if vim.bo[vim.api.nvim_win_get_buf(win)].modified then
+                return true
+            end
+        end
+        return false
+    end,
+        is_modified = function()
+        wins = api.get_tab_wins(tabid)
+        for i, x in pairs(wins) do
+            if vim.bo[vim.api.nvim_win_get_buf(x)].modified then
+                return true
+            end
+        end
+        return false
+    end,
+    is_modified = function()
+        wins = api.get_tab_wins(tabid)
+        for i, x in pairs(wins) do
+            if vim.bo[vim.api.nvim_win_get_buf(x)].modified then
+                return true
+            end
+        end
+        return false
+    end,
   }
 end
 
@@ -116,12 +143,15 @@ function tabwins.new_win(winid, opt)
       -- require 'kyazdani42/nvim-web-devicons'
       local name = require('tabby.module.filename').tail(winid)
       local extension = vim.fn.fnamemodify(name, ':e')
-      local icon = require('nvim-web-devicons').get_icon(name, extension)
+      local icon = require('nvim-web-devicons').get_icon(name, extension, { default = true })
       return icon
     end,
     buf_name = function()
       return require('tabby.feature.buf_name').get(winid, opt.buf_name)
     end,
+    is_modified = function()
+      return vim.bo[buf.id].modified 
+    end
   }
 end
 


### PR DESCRIPTION
When trying to use File_Icon function with unknown Filetypes like NvimTree the Tabby line wasnt rendering properly
Example Configuration: 

`
    line.wins_in_tab(line.api.get_current_tab()).foreach(function(win)
      local hl = win.is_current() and theme.current_tab or theme.inactive_tab
      return {
        line.sep('', hl, theme.fill),
        win.file_icon(),
        win.buf_name(),
        get_modified(win.buf().id),
        line.sep('', hl, theme.fill),
        hl = hl,
        margin = ' ',
      }
 
`
Before
![image](https://user-images.githubusercontent.com/24194327/208514684-6cb77479-e5f1-4800-9c25-c6b36440fef8.png)

Adding the default value to the call of Devicon function fixes this. 

After 
![image](https://user-images.githubusercontent.com/24194327/208515348-996f67f4-1681-4c99-ab3c-47e1f10e9fb0.png)

