### PR TITLE
Fix: Render issues when no defined file icon exists in nvim-web-devicons

### DIFF
--- a/lua/tabby/feature/tabwins.lua
+++ b/lua/tabby/feature/tabwins.lua
@@ -116,7 +116,7 @@ function tabwins.new_win(winid, opt)
       -- require 'kyazdani42/nvim-web-devicons'
       local name = require('tabby.module.filename').tail(winid)
       local extension = vim.fn.fnamemodify(name, ':e')
-      local icon = require('nvim-web-devicons').get_icon(name, extension)
+      local icon = require('nvim-web-devicons').get_icon(name, extension, { default = true })
       return icon
     end,
     buf_name = function()


### PR DESCRIPTION


When trying to use File_Icon function with unknown Filetypes like NvimTree the Tabby line wasnt rendering properly
Example Configuration:

`
line.wins_in_tab(line.api.get_current_tab()).foreach(function(win)
local hl = win.is_current() and theme.current_tab or theme.inactive_tab
return {
line.sep('', hl, theme.fill),
win.file_icon(),
win.buf_name(),
line.sep('', hl, theme.fill),
hl = hl,
margin = ' ',
}

`
Before
![image](https://user-images.githubusercontent.com/24194327/208781763-5f23ac10-63ce-46e8-8088-a1e2be0686d8.png)

Adding the default value to the call of Devicon function fixes this.

After 
![image](https://user-images.githubusercontent.com/24194327/208781989-1646d083-4085-4fa9-a317-fbe693eee147.png)

P.S. I screwed up the the branch of the previous PR. That's why I'm redoing this one. 

