### PR TITLE
feat: add buf is_changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,15 @@ Object for buffer.
 buf.id                                                            *tabby.buf.id*
     id of buffer, buffer handle for nvim api.
 
+
+buf.is_changed()                                        *tabby.buf.is_changed()*
+    Get if buffer is changed.
+
+    Return: ~
+        boolean, true if there are unwritten changes, false if not
+        <https://neovim.io/doc/user/options.html#'buftype'> for details.
+
+
 buf.type()                                                    *tabby.buf.type()*
     Get buftype option.
 

--- a/doc/tabby.txt
+++ b/doc/tabby.txt
@@ -443,6 +443,12 @@ Object for buffer.
 buf.id                                                            *tabby.buf.id*
     id of buffer, buffer handle for nvim api.
 
+buf.is_changed()                                        *tabby.buf.is_changed()*
+    Get if buffer is changed.
+
+    Return: ~
+        boolean, true if there are unwritten changes, false if not
+
 buf.type()                                                    *tabby.buf.type()*
     Get buftype option.
 
@@ -450,7 +456,7 @@ buf.type()                                                    *tabby.buf.type()*
         buftype, normal buffer is an empty string. check |buftype| or
         <https://neovim.io/doc/user/options.html#'buftype'> for details.
 
-NODE                                                              *tabby-node*
+NODE                                                                *tabby-node*
 
 Node is the rendered unit for tabby. Node is a recursive structure. It can be:
 

--- a/lua/tabby/feature/tabwins.lua
+++ b/lua/tabby/feature/tabwins.lua
@@ -160,6 +160,7 @@ end
 
 ---@class TabbyBuf
 ---@field id number buffer id
+---@field is_changed fun():boolean return if buffer is changed
 ---@field type fun():string return buffer type
 
 ---new buf object
@@ -168,6 +169,9 @@ end
 function tabwins.new_buf(bufid)
   return {
     id = bufid,
+    is_changed = function()
+      return api.get_buf_is_changed(bufid)
+    end,
     type = function()
       return api.get_buf_type(bufid)
     end,

--- a/lua/tabby/module/api.lua
+++ b/lua/tabby/module/api.lua
@@ -12,6 +12,9 @@ local api = {}
 ---@field get_win_tab fun(winid):number get tab of this win
 ---@field is_float_win fun(winid:number):boolean return true if this window is floating
 ---@field is_not_float_win fun(winid:number):boolean return true if this window is not floating
+---@field get_win_buf fun(winid:number):number get buffer of this window
+---@field get_buf_type fun(bufid:number):string get buffer type
+---@field get_buf_is_changed fun(bufid:number):boolean get buffer is changed
 
 function api.get_tabs()
   return vim.api.nvim_list_tabpages()
@@ -57,6 +60,10 @@ end
 
 function api.get_buf_type(bufid)
   return vim.api.nvim_buf_get_option(bufid, 'buftype')
+end
+
+function api.get_buf_is_changed(bufid)
+  return vim.fn.getbufinfo(bufid)[1].changed == 1
 end
 
 ---@type TabbyAPI


### PR DESCRIPTION
Add a function to see if a buffer is changed or not. Can be used to show an indicator when there are unwritten changes.

Example of using `is_changed()`
```lua
line.wins_in_tab(line.api.get_current_tab()).foreach(function(win)
  return {
    line.sep(" ", theme.win, theme.fill),
    win.buf().is_changed() and "" or "",
    win.buf_name(),
    line.sep("", theme.win, theme.fill),
    hl = theme.win,
    margin = " ",
  }
end),
```