### PR TITLE
fix: syntax errors in preset example

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,21 +529,24 @@ To use preset, you can use `use_preset({name}, {opt?})`, for example:
 ```lua
 require('tabby.tabline').use_preset('active_wins_at_tail', {
   theme = {
-    fill = 'TabLineFill', -- tabline background
-    head = 'TabLine', -- head element highlight
+    fill = 'TabLineFill',       -- tabline background
+    head = 'TabLine',           -- head element highlight
     current_tab = 'TabLineSel', -- current tab label highlight
-    tab = 'TabLine', -- other tab label highlight
-    win = 'TabLine', -- window highlight
-    tail = 'TabLine', -- tail element highlight
+    tab = 'TabLine',            -- other tab label highlight
+    win = 'TabLine',            -- window highlight
+    tail = 'TabLine',           -- tail element highlight
   },
-  nerdfont = true, -- whether use nerdfont
-  lualine_theme = nil -- lualine theme name
+  nerdfont = true,              -- whether use nerdfont
+  lualine_theme = nil,          -- lualine theme name
   tab_name = {
-      name_fallback = 'function({tabid}), return a string',
+    name_fallback = function(tabid)
+      return tabid
+    end,
   },
   buf_name = {
-      mode = "'unique'|'relative'|'tail'|'shorten'",
+    mode = "'unique'|'relative'|'tail'|'shorten'",
   },
+
 })
 ```
 


### PR DESCRIPTION
There was a missing comma and name_fallback needs to be an actual function