### PR TITLE
feat: foreach enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,25 +295,30 @@ require('tabby').setup({
 ### Line
 
 ```vimdoc
-line.tabs().foreach({callback})                    *tabby.line.tabs().foreach()*
+line.tabs().foreach({callback}, {params})          *tabby.line.tabs().foreach()*
     Use callback function to renderer every tabs.
 
     Parameters: ~
-        {callback}  Function, receive a Tab |tabby-tab|, return a
-                    Node |tabby-node|. Skip render when return is empty string.
+        {callback}  Function, receive a Tab |tabby-tab|, index and number of
+                    tabs, return a Node |tabby-node|. Skip render when return is
+                    empty string.
+        {props}     Additional properties added to the returned node.
 
     Return: ~
         Node |tabby-node|, rendered result of all tabs.
 
-line.wins({filter...}).foreach({callback})         *tabby.line.wins().foreach()*
+                                                   *tabby.line.wins().foreach()*
+line.wins({filter...}).foreach({callback}, {props})
     Use callback function to renderer every wins.
 
     Parameters: ~
         {filter...}  Filter functions. Each function receive a |tabby-win| and
                      return a boolean. If filter return false, this window won't
                      be displayed in tabline.
-        {callback}   Function, receive a Win |tabby-win|, return a
-                     Node |tabby-node|. Skip render when return is empty string.
+        {callback}   Function, receive a Win |tabby-win|, index and number of
+                     wins, return a Node |tabby-node|. Skip render when return
+                     is empty string.
+        {props}      Additional properties added to the returned node.
 
     Return: ~
         Node |tabby-node|, rendered result of all wins.
@@ -338,8 +343,9 @@ line.wins_in_tab({tabid}, {filter...}).foreach({callback})
         {filter...}  Filter functions. Each function receive a |tabby-win| and
                      return a boolean. If filter return false, this window won't
                      be displayed in tabline.
-        {callback}   Function, receive a Win |tabby-win|, return a
-                     Node |tabby-node|. Skip render when return is empty string.
+        {callback}   Function, receive a Win |tabby-win|, index and number of
+                     wins, return a Node |tabby-node|. Skip render when return
+                     is empty string.
 
     Return: ~
         Node |tabby-node|, rendered result of all wins in specified tab.

--- a/lua/tabby/feature/tabwins.lua
+++ b/lua/tabby/feature/tabwins.lua
@@ -87,13 +87,16 @@ function tabwins.new_tabs(opt)
   end, api.get_tabs())
   return {
     tabs = tabs,
-    foreach = function(fn)
+    foreach = function(fn, params)
       local nodes = {}
       for _, tab in ipairs(tabs) do
         local node = fn(tab)
         if node ~= nil and node ~= '' then
           nodes[#nodes + 1] = wrap_tab_node(node, tab.id)
         end
+      end
+      if params ~= nil then
+        nodes = vim.tbl_extend('keep', nodes, params)
       end
       return nodes
     end,
@@ -157,13 +160,16 @@ function tabwins.new_wins(win_ids, opt, ...)
   end
   return {
     wins = wins,
-    foreach = function(fn)
+    foreach = function(fn, params)
       local nodes = {}
       for _, win in ipairs(wins) do
         local node = fn(win)
         if node ~= nil and node ~= '' then
           nodes[#nodes + 1] = node
         end
+      end
+      if params ~= nil then
+        nodes = vim.tbl_extend('keep', nodes, params)
       end
       return nodes
     end,

--- a/lua/tabby/feature/tabwins.lua
+++ b/lua/tabby/feature/tabwins.lua
@@ -71,7 +71,9 @@ local function wrap_tab_node(node, tabid)
   if type(node) == 'string' then
     return { node, click = { 'to_tab', tabid } }
   elseif type(node) == 'table' then
-    node.click = { 'to_tab', tabid }
+    if node.click == nil then
+      node.click = { 'to_tab', tabid }
+    end
     return node
   else
     return ''
@@ -87,7 +89,7 @@ function tabwins.new_tabs(opt)
   end, api.get_tabs())
   return {
     tabs = tabs,
-    foreach = function(fn, params)
+    foreach = function(fn, props)
       local nodes = {}
       for i, tab in ipairs(tabs) do
         local node = fn(tab, i, #tabs)
@@ -95,8 +97,8 @@ function tabwins.new_tabs(opt)
           nodes[#nodes + 1] = wrap_tab_node(node, tab.id)
         end
       end
-      if params ~= nil then
-        nodes = vim.tbl_extend('keep', nodes, params)
+      if props ~= nil then
+        nodes = vim.tbl_extend('keep', nodes, props)
       end
       return nodes
     end,
@@ -160,7 +162,7 @@ function tabwins.new_wins(win_ids, opt, ...)
   end
   return {
     wins = wins,
-    foreach = function(fn, params)
+    foreach = function(fn, props)
       local nodes = {}
       for i, win in ipairs(wins) do
         local node = fn(win, i, #wins)
@@ -168,8 +170,8 @@ function tabwins.new_wins(win_ids, opt, ...)
           nodes[#nodes + 1] = node
         end
       end
-      if params ~= nil then
-        nodes = vim.tbl_extend('keep', nodes, params)
+      if props ~= nil then
+        nodes = vim.tbl_extend('keep', nodes, props)
       end
       return nodes
     end,

--- a/lua/tabby/feature/tabwins.lua
+++ b/lua/tabby/feature/tabwins.lua
@@ -89,8 +89,8 @@ function tabwins.new_tabs(opt)
     tabs = tabs,
     foreach = function(fn, params)
       local nodes = {}
-      for _, tab in ipairs(tabs) do
-        local node = fn(tab)
+      for i, tab in ipairs(tabs) do
+        local node = fn(tab, i, #tabs)
         if node ~= nil and node ~= '' then
           nodes[#nodes + 1] = wrap_tab_node(node, tab.id)
         end
@@ -162,8 +162,8 @@ function tabwins.new_wins(win_ids, opt, ...)
     wins = wins,
     foreach = function(fn, params)
       local nodes = {}
-      for _, win in ipairs(wins) do
-        local node = fn(win)
+      for i, win in ipairs(wins) do
+        local node = fn(win, i, #wins)
         if node ~= nil and node ~= '' then
           nodes[#nodes + 1] = node
         end

--- a/lua/tabby/feature/tabwins.lua
+++ b/lua/tabby/feature/tabwins.lua
@@ -65,7 +65,7 @@ end
 
 ---@class TabbyTabs
 ---@field tabs TabbyTab[] tabs
----@field foreach fun(fn:fun(tab:TabbyTab):TabbyNode):TabbyNode render tabs by given render function
+---@field foreach fun(fn:fun(tab:TabbyTab,i:number,n:number):TabbyNode,props:TabbyNode):TabbyNode render tabs by given render function
 
 local function wrap_tab_node(node, tabid)
   if type(node) == 'string' then
@@ -144,7 +144,7 @@ end
 
 ---@class TabbyWins
 ---@field wins TabbyWin[] windows
----@field foreach fun(fn:fun(win:TabbyWin):TabbyNode):TabbyNode render wins by given render function
+---@field foreach fun(fn:fun(win:TabbyWin,i:number,n:number):TabbyNode,props:TabbyNode):TabbyNode render wins by given render function
 
 ---@alias WinFilter fun(win:TabbyWin):boolean filter for window
 


### PR DESCRIPTION
General improvements to `tabs.foreach()` and `wins.foreach()` functions.

### `props`

You can pass an object with additional properties after the render function to add them to the resulting `TabbyNode`, like `hl` or `margin`. Useful to add spaces between tabs since margin isn't inherited by child nodes.

### length and index arguments

In addition to `TabbyTab`/`TabbyWin` object passed to the render function it will also pass current tab/win's index and total number of tabs/wins. Useful to check if current tab or win is first or last to add proper separators.

### not overriding user defined click events

Before adding default click handle to switch to clicked tab, `wrap_tab_node` function in `tabs.foreach()` will now check if returned node has already defined its own handle to prevent overriding it.