### PR TITLE
feat: buf_name override

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ line.api                                                        *tabby.line.api*
     },
     buf_name = {
         mode = "'unique'|'relative'|'tail'|'shorten'",
+        override = function(bufid) return nil end,
     }
 }
 ```
@@ -419,6 +420,12 @@ the result of every mode are:
 - relative: "a_repo/api/user.py", "b_repo/api/user.py", "b_repo/api/admin.py"
 - tail: "user.py", "user.py", "admin.py"
 - shorten: "r/a/user.py", "r/b/user.py", "r/b/admin.py"
+
+Additionally, you can override the default name of the buffer by providing
+`option.buf_name.override` function (ref: [Line Option](#Line Option)) which is
+going to force tabby to display whatever string it returns, unless it is `nil`,
+in which case it falls back to default behavior. It can be used to display a
+more meaningful name for temporary buffers, like ones used by [vim-fugitive](https://github.com/tpope/vim-fugitive).
 
 ### Tab
 
@@ -639,6 +646,7 @@ require('tabby').setup({
     },
     buf_name = {
       mode = "'unique'|'relative'|'tail'|'shorten'",
+      override = function(bufid) return nil end,
     },
   },
 })

--- a/lua/tabby/feature/buf_name.lua
+++ b/lua/tabby/feature/buf_name.lua
@@ -4,11 +4,13 @@ local filename = require('tabby.module.filename')
 
 ---@class TabbyBufNameOption
 ---@field mode 'unique'|'relative'|'tail'|'shorten' @default unique
+---@field placeholder string @default '[No Name]'
 ---@field override fun(bufid:number):string?
 
 ---@type TabbyBufNameOption
 local default_option = {
   mode = 'unique',
+  placeholder = '[No Name]',
   override = function()
     return nil
   end,
@@ -33,40 +35,44 @@ function buf_name.get(winid, opt)
     return override
   end
   if o.mode == 'unique' then
-    return buf_name.get_unique_name(winid)
+    return buf_name.get_unique_name(winid, o.placeholder)
   elseif o.mode == 'relative' then
-    return buf_name.get_relative_name(winid)
+    return buf_name.get_relative_name(winid, o.placeholder)
   elseif o.mode == 'tail' then
-    return buf_name.get_tail_name(winid)
+    return buf_name.get_tail_name(winid, o.placeholder)
   elseif o.mode == 'shorten' then
-    return buf_name.get_shorten_name(winid)
+    return buf_name.get_shorten_name(winid, o.placeholder)
   else
     return ''
   end
 end
 
 ---@param winid number
+---@param placeholder string?
 ---@return string filename
-function buf_name.get_unique_name(winid)
-  return filename.unique(winid)
+function buf_name.get_unique_name(winid, placeholder)
+  return filename.unique(winid, placeholder)
 end
 
 ---@param winid number
+---@param placeholder string?
 ---@return string filename
-function buf_name.get_relative_name(winid)
-  return filename.relative(winid)
+function buf_name.get_relative_name(winid, placeholder)
+  return filename.relative(winid, placeholder)
 end
 
 ---@param winid number
+---@param placeholder string?
 ---@return string filename
-function buf_name.get_tail_name(winid)
-  return filename.tail(winid)
+function buf_name.get_tail_name(winid, placeholder)
+  return filename.tail(winid, placeholder)
 end
 
 ---@param winid number
+---@param placeholder string?
 ---@return string filename
-function buf_name.get_shorten_name(winid)
-  return filename.shorten(winid)
+function buf_name.get_shorten_name(winid, placeholder)
+  return filename.shorten(winid, placeholder)
 end
 
 return buf_name

--- a/lua/tabby/feature/buf_name.lua
+++ b/lua/tabby/feature/buf_name.lua
@@ -8,6 +8,7 @@ local filename = require('tabby.module.filename')
 ---@type TabbyBufNameOption
 local default_option = {
   mode = 'unique',
+  override = function() return nil end,
 }
 
 function buf_name.set_default_option(opt)
@@ -22,6 +23,11 @@ function buf_name.get(winid, opt)
   local o = default_option
   if opt ~= nil then
     o = vim.tbl_deep_extend('force', default_option, opt)
+  end
+  local bufid = vim.api.nvim_win_get_buf(winid)
+  local override = o.override(bufid)
+  if override ~= nil then
+      return override
   end
   if o.mode == 'unique' then
     return buf_name.get_unique_name(winid)

--- a/lua/tabby/feature/buf_name.lua
+++ b/lua/tabby/feature/buf_name.lua
@@ -3,7 +3,8 @@ local buf_name = {}
 local filename = require('tabby.module.filename')
 
 ---@class TabbyBufNameOption
----@field mode 'unique'|'relative'|'tail'|'shorten' @defult unique
+---@field mode 'unique'|'relative'|'tail'|'shorten' @default unique
+---@field override fun(bufid:number):string?
 
 ---@type TabbyBufNameOption
 local default_option = {

--- a/lua/tabby/feature/buf_name.lua
+++ b/lua/tabby/feature/buf_name.lua
@@ -8,7 +8,9 @@ local filename = require('tabby.module.filename')
 ---@type TabbyBufNameOption
 local default_option = {
   mode = 'unique',
-  override = function() return nil end,
+  override = function()
+    return nil
+  end,
 }
 
 function buf_name.set_default_option(opt)
@@ -27,7 +29,7 @@ function buf_name.get(winid, opt)
   local bufid = vim.api.nvim_win_get_buf(winid)
   local override = o.override(bufid)
   if override ~= nil then
-      return override
+    return override
   end
   if o.mode == 'unique' then
     return buf_name.get_unique_name(winid)

--- a/lua/tabby/feature/tab_name.lua
+++ b/lua/tabby/feature/tab_name.lua
@@ -13,7 +13,7 @@ local default_option = {
   name_fallback = function(tabid)
     local wins = api.get_tab_wins(tabid)
     local cur_win = api.get_tab_current_win(tabid)
-    local name = ''
+    local name
     if api.is_float_win(cur_win) then
       name = '[Floating]'
     else

--- a/lua/tabby/module/filename.lua
+++ b/lua/tabby/module/filename.lua
@@ -7,8 +7,6 @@ vim.cmd([[
   augroup end
 ]])
 
-local noname_placeholder = '[No Name]'
-
 local function relative(name)
   return vim.fn.fnamemodify(name, ':~:.')
 end
@@ -117,7 +115,7 @@ function unique_names:build()
       buffer_ids[bufid] = {}
       local name = vim.api.nvim_buf_get_name(bufid)
       if name == '' then
-        self:set(bufid, noname_placeholder)
+        self:set(bufid, name)
       else
         name = relative(name)
         self:insert_index(bufid, tail(name), head(name))
@@ -144,42 +142,46 @@ function filename.flush_unique_name_cache()
   unique_names:init()
 end
 
-local function wrap_name(name)
+local function wrap_name(name, placeholder)
   if (name or '') == '' then
-    return noname_placeholder
+    return placeholder or '[No Name]'
   end
   return name
 end
 
 ---@param winid number
+---@param placeholder string?
 ---@return string filename
-function filename.relative(winid)
+function filename.relative(winid, placeholder)
   local bufid = vim.api.nvim_win_get_buf(winid)
   local fname = vim.api.nvim_buf_get_name(bufid)
-  return wrap_name(relative(fname))
+  return wrap_name(relative(fname), placeholder)
 end
 
 ---@param winid number
+---@param placeholder string?
 ---@return string filename
-function filename.tail(winid)
+function filename.tail(winid, placeholder)
   local bufid = vim.api.nvim_win_get_buf(winid)
   local fname = vim.api.nvim_buf_get_name(bufid)
-  return wrap_name(tail(fname))
+  return wrap_name(tail(fname), placeholder)
 end
 
 ---@param winid number
+---@param placeholder string?
 ---@return string filename
-function filename.shorten(winid)
+function filename.shorten(winid, placeholder)
   local bufid = vim.api.nvim_win_get_buf(winid)
   local fname = vim.api.nvim_buf_get_name(bufid)
-  return wrap_name(shorten(fname))
+  return wrap_name(shorten(fname), placeholder)
 end
 
 ---@param winid number
+---@param placeholder string?
 ---@return string filename
-function filename.unique(winid)
+function filename.unique(winid, placeholder)
   local bufid = vim.api.nvim_win_get_buf(winid)
-  return wrap_name(unique_names:get_name(bufid))
+  return wrap_name(unique_names:get_name(bufid), placeholder)
 end
 
 return filename

--- a/lua/tabby/presets.lua
+++ b/lua/tabby/presets.lua
@@ -23,7 +23,7 @@ local function clear_tab_label(tabid, active)
   local name = tab_name.get_raw(tabid)
   local number = vim.api.nvim_tabpage_get_number(tabid)
   local wins = api.get_tab_wins(tabid)
-  local labels = {}
+  local labels
   if name == '' then
     labels = { '', icon, number, string.format('[%d]', #wins), '' }
   else


### PR DESCRIPTION
Add a new option in `TabbyLineOption.buf_name` called `override` which is a function that takes `bufid` and returns optional string. If `nil` is returned, `win.buf_name()` returns as normal, but if any string is returned, `win.buf_name()` returns it without any changes.

It's useful for giving distinctive names to temporary buffers that otherwise have either unhelpful or empty names. For example, for [vim-fugitive](https://github.com/tpope/vim-fugitive) temp buffers:

```lua
require('tabby').setup({
  option = {
    buf_name = {
      override = function(bufid)
        local filetype = vim.api.nvim_buf_get_option(bufid, 'filetype')
        if filetype ~= 'git' then return nil end  -- Display default name for everything else

        local fugitive_info = vim.fn.FugitiveResult(vim.api.nvim_buf_get_name(bufid))
        return 'git ' .. table.concat(fugitive_info.args, ' ')  -- Display respective git command
      end,
    },
  },
})
```