### PR TITLE
feat: line.bufs().foreach()

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,20 @@ line.wins_in_tab({tabid}, {filter...}).foreach({callback})
     Example: ~
         - Don't display NvimTree: See |tabby.line.wins().foreach()|.
 
+                                            *tabby.line.bufs().foreach()*
+line.bufs({filter...}).foreach({callback})
+    Use callback function to renderer every bufs.
+
+    Parameters: ~
+        {filter...}  Filter functions. Each function receive a |tabby-buf| and
+                     return a boolean. If filter return false, this window won't
+                     be displayed in tabline.
+        {callback}   Function, receive a Buf |tabby-buf|, return a
+                     Node |tabby-node|. Skip render when return is empty string.
+
+    Return: ~
+        Node |tabby-node|, rendered result of all bufs.
+
 line.spacer()                                              *tabby.line.spacer()*
     Separation point between alignment sections. Each section will be separated
     by an equal number of spaces.
@@ -520,12 +534,33 @@ buf.id                                                            *tabby.buf.id*
     id of buffer, buffer handle for nvim api.
 
 
+buf.is_current()                                        *tabby.buf.is_current()*
+
+    Return: ~
+        Boolean, if this buffer is a buffer of the current window.
+
+
 buf.is_changed()                                        *tabby.buf.is_changed()*
     Get if buffer is changed.
 
     Return: ~
         boolean, true if there are unwritten changes, false if not
         <https://neovim.io/doc/user/options.html#'buftype'> for details.
+
+
+buf.file_icon()                                          *tabby.buf.file_icon()*
+    Get file icon of filetype. You need to installed plugin
+    'kyazdani42/nvim-web-devicons'.
+
+    Return: ~
+        Node |tabby-node|, file icon.
+
+
+buf.name()                                                    *tabby.buf.name()*
+
+    Return: ~
+        String, name of this buffer. You can specify the form by using
+        option ".buf_name.mode" in LineOption |tabby-line-option|.
 
 
 buf.type()                                                    *tabby.buf.type()*
@@ -609,6 +644,9 @@ api.is_float_win({winid})                             *tabby.api.is_float_win()*
 
 api.is_not_float_win({winid})                     *tabby.api.is_not_float_win()*
     Return true if this window is not floating.
+
+api.get_bufs()                                            *tabby.api.get_bufs()*
+    Get all listed buf ids
 ```
 
 ## Use Presets

--- a/lua/tabby/feature/buf_name.lua
+++ b/lua/tabby/feature/buf_name.lua
@@ -18,19 +18,19 @@ end
 ---@param winid number
 ---@param opt? TabbyBufNameOption
 ---@return string
-function buf_name.get(winid, opt)
+function buf_name.get(bufid, opt)
   local o = default_option
   if opt ~= nil then
     o = vim.tbl_deep_extend('force', default_option, opt)
   end
   if o.mode == 'unique' then
-    return buf_name.get_unique_name(winid)
+    return buf_name.get_unique_name(bufid)
   elseif o.mode == 'relative' then
-    return buf_name.get_relative_name(winid)
+    return buf_name.get_relative_name(bufid)
   elseif o.mode == 'tail' then
-    return buf_name.get_tail_name(winid)
+    return buf_name.get_tail_name(bufid)
   elseif o.mode == 'shorten' then
-    return buf_name.get_shorten_name(winid)
+    return buf_name.get_shorten_name(bufid)
   else
     return ''
   end
@@ -38,26 +38,26 @@ end
 
 ---@param winid number
 ---@return string filename
-function buf_name.get_unique_name(winid)
-  return filename.unique(winid)
+function buf_name.get_unique_name(bufid)
+  return filename.unique(bufid)
 end
 
 ---@param winid number
 ---@return string filename
-function buf_name.get_relative_name(winid)
-  return filename.relative(winid)
+function buf_name.get_relative_name(bufid)
+  return filename.relative(bufid)
 end
 
 ---@param winid number
 ---@return string filename
-function buf_name.get_tail_name(winid)
-  return filename.tail(winid)
+function buf_name.get_tail_name(bufid)
+  return filename.tail(bufid)
 end
 
 ---@param winid number
 ---@return string filename
-function buf_name.get_shorten_name(winid)
-  return filename.shorten(winid)
+function buf_name.get_shorten_name(bufid)
+  return filename.shorten(bufid)
 end
 
 return buf_name

--- a/lua/tabby/feature/buf_name.lua
+++ b/lua/tabby/feature/buf_name.lua
@@ -18,13 +18,13 @@ end
 ---@param winid number
 ---@param opt? TabbyBufNameOption
 ---@return string
-function buf_name.get(bufid, opt)
+function buf_name.get(bufid, opt, use_bufs)
   local o = default_option
   if opt ~= nil then
     o = vim.tbl_deep_extend('force', default_option, opt)
   end
   if o.mode == 'unique' then
-    return buf_name.get_unique_name(bufid)
+    return buf_name.get_unique_name(bufid, use_bufs)
   elseif o.mode == 'relative' then
     return buf_name.get_relative_name(bufid)
   elseif o.mode == 'tail' then
@@ -38,8 +38,8 @@ end
 
 ---@param winid number
 ---@return string filename
-function buf_name.get_unique_name(bufid)
-  return filename.unique(bufid)
+function buf_name.get_unique_name(bufid, use_bufs)
+  return filename.unique(bufid, use_bufs)
 end
 
 ---@param winid number

--- a/lua/tabby/feature/buf_name.lua
+++ b/lua/tabby/feature/buf_name.lua
@@ -3,7 +3,7 @@ local buf_name = {}
 local filename = require('tabby.module.filename')
 
 ---@class TabbyBufNameOption
----@field mode 'unique'|'relative'|'tail'|'shorten' @defult unique
+---@field mode 'unique'|'relative'|'tail'|'shorten' @default unique
 
 ---@type TabbyBufNameOption
 local default_option = {
@@ -15,8 +15,9 @@ function buf_name.set_default_option(opt)
 end
 
 ---get buf name
----@param winid number
+---@param bufid number
 ---@param opt? TabbyBufNameOption
+---@param use_bufs boolean
 ---@return string
 function buf_name.get(bufid, opt, use_bufs)
   local o = default_option
@@ -36,25 +37,26 @@ function buf_name.get(bufid, opt, use_bufs)
   end
 end
 
----@param winid number
+---@param bufid number
+---@param use_bufs boolean
 ---@return string filename
 function buf_name.get_unique_name(bufid, use_bufs)
   return filename.unique(bufid, use_bufs)
 end
 
----@param winid number
+---@param bufid number
 ---@return string filename
 function buf_name.get_relative_name(bufid)
   return filename.relative(bufid)
 end
 
----@param winid number
+---@param bufid number
 ---@return string filename
 function buf_name.get_tail_name(bufid)
   return filename.tail(bufid)
 end
 
----@param winid number
+---@param bufid number
 ---@return string filename
 function buf_name.get_shorten_name(bufid)
   return filename.shorten(bufid)

--- a/lua/tabby/feature/lines.lua
+++ b/lua/tabby/feature/lines.lua
@@ -44,7 +44,7 @@ function lines.get_line(opt)
       return tabwins.new_wins(api.get_tab_wins(tabid), opt, ...)
     end,
     bufs = function(...)
-        return tabwins.new_bufs(opt, ...)
+      return tabwins.new_bufs(opt, ...)
     end,
     sep = function(symbol, cur_hl, back_hl)
       local cur_hl_obj = ensure_hl_obj(cur_hl)

--- a/lua/tabby/feature/lines.lua
+++ b/lua/tabby/feature/lines.lua
@@ -9,6 +9,7 @@ local tabwins = require('tabby.feature.tabwins')
 ---@field tabs fun():TabbyTabs return all tabs
 ---@field wins fun(...:WinFilter):TabbyWins return all wins
 ---@field wins_in_tab fun(tabid:number,...:WinFilter):TabbyWins return all wins in that tab
+---@field bufs fun(...:BufFilter):TabbyBufs return all bufs
 ---@field sep fun(symbol:string,cur_hl:TabbyHighlight,back_hl:TabbyHighlight):TabbyNode make a separator
 ---@field spacer fun():TabbyNode Separation point between alignment sections. Each section will be separated by an equal number of spaces.
 ---@field truncate_point fun():TabbyNode Where to truncate line if too long. Default is at the start. Only first point will be active.

--- a/lua/tabby/feature/lines.lua
+++ b/lua/tabby/feature/lines.lua
@@ -43,6 +43,9 @@ function lines.get_line(opt)
     wins_in_tab = function(tabid, ...)
       return tabwins.new_wins(api.get_tab_wins(tabid), opt, ...)
     end,
+    bufs = function(...)
+        return tabwins.new_bufs(opt, ...)
+    end,
     sep = function(symbol, cur_hl, back_hl)
       local cur_hl_obj = ensure_hl_obj(cur_hl)
       local back_hl_obj = ensure_hl_obj(back_hl)

--- a/lua/tabby/feature/tab_name.lua
+++ b/lua/tabby/feature/tab_name.lua
@@ -17,7 +17,8 @@ local default_option = {
     if api.is_float_win(cur_win) then
       name = '[Floating]'
     else
-      name = buf_name.get(cur_win)
+      local bufid = vim.api.nvim_win_get_buf(cur_win)
+      name = buf_name.get(bufid)
     end
     if #wins > 1 then
       name = string.format('%s[%d+]', name, #wins - 1)

--- a/lua/tabby/feature/tabwins.lua
+++ b/lua/tabby/feature/tabwins.lua
@@ -145,7 +145,7 @@ end
 
 ---@alias WinFilter fun(win:TabbyWin):boolean filter for window
 
----new win object
+---new TabbyWins
 ---@param win_ids number[] win id list
 ---@param opt TabbyLineOption
 ---@param ... WinFilter
@@ -174,13 +174,17 @@ end
 
 ---@class TabbyBuf
 ---@field id number buffer id
+---@field is_current fun():boolean return if buffer is a buffer of the current window
 ---@field is_changed fun():boolean return if buffer is changed
+---@field file_icon fun():string? file icon, require devicons
+---@field name fun():string file name
 ---@field type fun():string return buffer type
 
----new buf object
----@param bufid any
----@return table
-function tabwins.new_buf(bufid)
+---new TabbyBuf
+---@param bufid number
+---@param opt TabbyLineOption
+---@return TabbyBuf
+function tabwins.new_buf(bufid, opt)
   return {
     id = bufid,
     is_current = function()
@@ -205,6 +209,12 @@ function tabwins.new_buf(bufid)
   }
 end
 
+---@class TabbyBufs
+---@field bufs TabbyBuf[] buffers
+---@field foreach fun(fn:fun(buf:TabbyBuf):TabbyNode):TabbyNode render bufs by given render function
+
+---@alias BufFilter fun(buf:TabbyBuf):boolean filter for buffer
+
 local function wrap_buf_node(node, bufid)
   if type(node) == 'string' then
     return { node, click = { 'to_buf', bufid } }
@@ -216,6 +226,10 @@ local function wrap_buf_node(node, bufid)
   end
 end
 
+---new TabbyBufs
+---@param opt TabbyLineOption
+---@param ... BufFilter
+---@return TabbyBufs
 function tabwins.new_bufs(opt, ...)
   local bufs = vim.tbl_map(function(bufid)
     return tabwins.new_buf(bufid, opt)

--- a/lua/tabby/feature/tabwins.lua
+++ b/lua/tabby/feature/tabwins.lua
@@ -205,6 +205,17 @@ function tabwins.new_buf(bufid)
   }
 end
 
+local function wrap_buf_node(node, bufid)
+  if type(node) == 'string' then
+    return { node, click = { 'to_buf', bufid } }
+  elseif type(node) == 'table' then
+    node.click = { 'to_buf', bufid }
+    return node
+  else
+    return ''
+  end
+end
+
 function tabwins.new_bufs(opt, ...)
   local bufids = api.get_bufs()
   table.sort(bufids, function(a, b)
@@ -223,7 +234,7 @@ function tabwins.new_bufs(opt, ...)
       for _, buf in ipairs(bufs) do
         local node = fn(buf)
         if node ~= nil and node ~= '' then
-          nodes[#nodes + 1] = node
+          nodes[#nodes + 1] = wrap_buf_node(node, buf.id)
         end
       end
       return nodes

--- a/lua/tabby/feature/tabwins.lua
+++ b/lua/tabby/feature/tabwins.lua
@@ -217,13 +217,9 @@ local function wrap_buf_node(node, bufid)
 end
 
 function tabwins.new_bufs(opt, ...)
-  local bufids = api.get_bufs()
-  table.sort(bufids, function(a, b)
-    return vim.api.nvim_buf_get_name(a) < vim.api.nvim_buf_get_name(b)
-  end)
   local bufs = vim.tbl_map(function(bufid)
     return tabwins.new_buf(bufid)
-  end, bufids)
+  end, api.get_bufs())
   for _, filter in ipairs({ ... }) do
     bufs = vim.tbl_filter(filter, bufs)
   end

--- a/lua/tabby/feature/tabwins.lua
+++ b/lua/tabby/feature/tabwins.lua
@@ -119,7 +119,7 @@ function tabwins.new_win(winid, opt)
       return tabwins.new_tab(api.get_win_tab(winid), opt)
     end,
     buf = function()
-      return tabwins.new_buf(api.get_win_buf(winid))
+      return tabwins.new_buf(api.get_win_buf(winid), opt)
     end,
     is_current = function()
       return api.get_tab_current_win(api.get_win_tab(winid)) == winid
@@ -197,7 +197,7 @@ function tabwins.new_buf(bufid)
       return icon
     end,
     name = function()
-      return require('tabby.module.filename').unique(bufid, true)
+      return require('tabby.feature.buf_name').get(bufid, opt.buf_name, true)
     end,
     type = function()
       return api.get_buf_type(bufid)
@@ -218,7 +218,7 @@ end
 
 function tabwins.new_bufs(opt, ...)
   local bufs = vim.tbl_map(function(bufid)
-    return tabwins.new_buf(bufid)
+    return tabwins.new_buf(bufid, opt)
   end, api.get_bufs())
   for _, filter in ipairs({ ... }) do
     bufs = vim.tbl_filter(filter, bufs)

--- a/lua/tabby/feature/tabwins.lua
+++ b/lua/tabby/feature/tabwins.lua
@@ -206,9 +206,13 @@ function tabwins.new_buf(bufid)
 end
 
 function tabwins.new_bufs(opt, ...)
+  local bufids = api.get_bufs()
+  table.sort(bufids, function(a, b)
+    return vim.api.nvim_buf_get_name(a) < vim.api.nvim_buf_get_name(b)
+  end)
   local bufs = vim.tbl_map(function(bufid)
     return tabwins.new_buf(bufid)
-  end, api.get_bufs())
+  end, bufids)
   for _, filter in ipairs({ ... }) do
     bufs = vim.tbl_filter(filter, bufs)
   end

--- a/lua/tabby/feature/tabwins.lua
+++ b/lua/tabby/feature/tabwins.lua
@@ -126,13 +126,15 @@ function tabwins.new_win(winid, opt)
     end,
     file_icon = function()
       -- require 'kyazdani42/nvim-web-devicons'
-      local name = require('tabby.module.filename').tail(winid)
+      local bufid = vim.api.nvim_win_get_buf(winid)
+      local name = require('tabby.module.filename').tail(bufid)
       local extension = vim.fn.fnamemodify(name, ':e')
       local icon = require('nvim-web-devicons').get_icon(name, extension, { default = true })
       return icon
     end,
     buf_name = function()
-      return require('tabby.feature.buf_name').get(winid, opt.buf_name)
+      local bufid = vim.api.nvim_win_get_buf(winid)
+      return require('tabby.feature.buf_name').get(bufid, opt.buf_name)
     end,
   }
 end
@@ -181,8 +183,21 @@ end
 function tabwins.new_buf(bufid)
   return {
     id = bufid,
+    is_current = function()
+        return vim.fn.bufnr('%') == bufid
+    end,
     is_changed = function()
       return api.get_buf_is_changed(bufid)
+    end,
+    file_icon = function()
+      -- require 'kyazdani42/nvim-web-devicons'
+      local name = require('tabby.module.filename').tail(bufid)
+      local extension = vim.fn.fnamemodify(name, ':e')
+      local icon = require('nvim-web-devicons').get_icon(name, extension, { default = true })
+      return icon
+    end,
+    name = function()
+        return require('tabby.module.filename').unique(bufid)
     end,
     type = function()
       return api.get_buf_type(bufid)

--- a/lua/tabby/feature/tabwins.lua
+++ b/lua/tabby/feature/tabwins.lua
@@ -197,7 +197,7 @@ function tabwins.new_buf(bufid)
       return icon
     end,
     name = function()
-        return require('tabby.module.filename').unique(bufid)
+        return require('tabby.module.filename').unique(bufid, true)
     end,
     type = function()
       return api.get_buf_type(bufid)

--- a/lua/tabby/feature/tabwins.lua
+++ b/lua/tabby/feature/tabwins.lua
@@ -190,4 +190,26 @@ function tabwins.new_buf(bufid)
   }
 end
 
+function tabwins.new_bufs(opt, ...)
+  local bufs = vim.tbl_map(function(bufid)
+    return tabwins.new_buf(bufid)
+  end, api.get_bufs())
+  for _, filter in ipairs({ ... }) do
+    bufs = vim.tbl_filter(filter, bufs)
+  end
+  return {
+    bufs = bufs,
+    foreach = function(fn)
+      local nodes = {}
+      for _, buf in ipairs(bufs) do
+        local node = fn(buf)
+        if node ~= nil and node ~= '' then
+          nodes[#nodes + 1] = node
+        end
+      end
+      return nodes
+    end,
+  }
+end
+
 return tabwins

--- a/lua/tabby/feature/tabwins.lua
+++ b/lua/tabby/feature/tabwins.lua
@@ -184,7 +184,7 @@ function tabwins.new_buf(bufid)
   return {
     id = bufid,
     is_current = function()
-        return vim.fn.bufnr('%') == bufid
+      return vim.fn.bufnr('%') == bufid
     end,
     is_changed = function()
       return api.get_buf_is_changed(bufid)
@@ -197,7 +197,7 @@ function tabwins.new_buf(bufid)
       return icon
     end,
     name = function()
-        return require('tabby.module.filename').unique(bufid, true)
+      return require('tabby.module.filename').unique(bufid, true)
     end,
     type = function()
       return api.get_buf_type(bufid)

--- a/lua/tabby/module/api.lua
+++ b/lua/tabby/module/api.lua
@@ -11,6 +11,7 @@ local api = {}
 ---@field get_win_tab fun(winid):number get tab of this win
 ---@field is_float_win fun(winid:number):boolean return true if this window is floating
 ---@field is_not_float_win fun(winid:number):boolean return true if this window is not floating
+---@field get_bufs fun():number[] get all listed buffers
 ---@field get_win_buf fun(winid:number):number get buffer of this window
 ---@field get_buf_type fun(bufid:number):string get buffer type
 ---@field get_buf_is_changed fun(bufid:number):boolean get buffer is changed

--- a/lua/tabby/module/api.lua
+++ b/lua/tabby/module/api.lua
@@ -54,8 +54,14 @@ function api.is_not_float_win(winid)
 end
 
 function api.get_bufs()
-  local bufs = vim.api.nvim_list_bufs()
-  return vim.tbl_filter(vim.api.nvim_buf_is_loaded, bufs)
+    local bufinfo = vim.fn.getbufinfo()
+    local bufs = {}
+    for _, buf in ipairs(bufinfo) do
+        if vim.api.nvim_buf_is_valid(buf.bufnr) and buf.listed == 1 then
+            bufs[#bufs + 1] = buf.bufnr
+        end
+    end
+    return bufs
 end
 
 function api.get_win_buf(winid)

--- a/lua/tabby/module/api.lua
+++ b/lua/tabby/module/api.lua
@@ -54,14 +54,14 @@ function api.is_not_float_win(winid)
 end
 
 function api.get_bufs()
-    local bufinfo = vim.fn.getbufinfo()
-    local bufs = {}
-    for _, buf in ipairs(bufinfo) do
-        if vim.api.nvim_buf_is_valid(buf.bufnr) and buf.listed == 1 then
-            bufs[#bufs + 1] = buf.bufnr
-        end
+  local bufinfo = vim.fn.getbufinfo()
+  local bufs = {}
+  for _, buf in ipairs(bufinfo) do
+    if vim.api.nvim_buf_is_valid(buf.bufnr) and buf.listed == 1 then
+      bufs[#bufs + 1] = buf.bufnr
     end
-    return bufs
+  end
+  return bufs
 end
 
 function api.get_win_buf(winid)

--- a/lua/tabby/module/api.lua
+++ b/lua/tabby/module/api.lua
@@ -53,6 +53,11 @@ function api.is_not_float_win(winid)
   return vim.api.nvim_win_get_config(winid).relative == ''
 end
 
+function api.get_bufs()
+  local bufs = vim.api.nvim_list_bufs()
+  return vim.tbl_filter(vim.api.nvim_buf_is_loaded, bufs)
+end
+
 function api.get_win_buf(winid)
   return vim.api.nvim_win_get_buf(winid)
 end

--- a/lua/tabby/module/builder.lua
+++ b/lua/tabby/module/builder.lua
@@ -55,6 +55,10 @@ function LineBuilder:add_click(click, heads, tails)
     local number = vim.api.nvim_tabpage_get_number(click[2])
     heads[#heads + 1] = self:lazy_add(string.format('%%%dX', number))
     tails[#tails + 1] = self:lazy_add('%X')
+  elseif click[1] == 'to_buf' then
+    local number = vim.fn.bufnr(click[2])
+    heads[#heads + 1] = self:lazy_add(string.format('%%%d@TabbyOpenBuffer@', click[2]))
+    tails[#tails + 1] = self:lazy_add('%X')
   elseif click[1] == 'customer' then
     heads[#heads + 1] = self:lazy_add(string.format('%%%d@TabbyCustomClickHandler@', click[2]))
     tails[#tails + 1] = self:lazy_add('%X')

--- a/lua/tabby/module/filename.lua
+++ b/lua/tabby/module/filename.lua
@@ -3,7 +3,7 @@ local filename = {}
 vim.cmd([[
   augroup highlight_cache
     autocmd!
-    autocmd WinNew,WinClosed,BufWinEnter,BufWinLeave * lua require("tabby.module.filename").flush_unique_name_cache()
+    autocmd WinNew,WinClosed,BufWinEnter,BufWinLeave,BufDelete * lua require("tabby.module.filename").flush_unique_name_cache()
   augroup end
 ]])
 

--- a/lua/tabby/module/filename.lua
+++ b/lua/tabby/module/filename.lua
@@ -138,6 +138,7 @@ function unique_names:build(use_bufs)
 end
 
 ---@param bufid number
+---@param use_bufs boolean
 ---@return string
 function unique_names:get_name(bufid, use_bufs)
   if self.names == nil then
@@ -179,6 +180,7 @@ function filename.shorten(bufid)
 end
 
 ---@param winid number
+---@param use_bufs boolean
 ---@return string filename
 function filename.unique(bufid, use_bufs)
   bufs = bufs or false

--- a/lua/tabby/module/filename.lua
+++ b/lua/tabby/module/filename.lua
@@ -109,12 +109,12 @@ function unique_names:build(use_bufs)
 
   local bufs = nil
   if use_bufs then
-      bufs = require('tabby.module.api').get_bufs()
+    bufs = require('tabby.module.api').get_bufs()
   else
-      local wins = vim.tbl_filter(function(winid)
-        return vim.api.nvim_win_get_config(winid).relative == ''
-      end, vim.api.nvim_list_wins())
-      bufs = vim.tbl_map(vim.api.nvim_win_get_buf, wins)
+    local wins = vim.tbl_filter(function(winid)
+      return vim.api.nvim_win_get_config(winid).relative == ''
+    end, vim.api.nvim_list_wins())
+    bufs = vim.tbl_map(vim.api.nvim_win_get_buf, wins)
   end
 
   local processed = {}

--- a/lua/tabby/module/filename.lua
+++ b/lua/tabby/module/filename.lua
@@ -153,32 +153,28 @@ end
 
 ---@param winid number
 ---@return string filename
-function filename.relative(winid)
-  local bufid = vim.api.nvim_win_get_buf(winid)
+function filename.relative(bufid)
   local fname = vim.api.nvim_buf_get_name(bufid)
   return wrap_name(relative(fname))
 end
 
 ---@param winid number
 ---@return string filename
-function filename.tail(winid)
-  local bufid = vim.api.nvim_win_get_buf(winid)
+function filename.tail(bufid)
   local fname = vim.api.nvim_buf_get_name(bufid)
   return wrap_name(tail(fname))
 end
 
 ---@param winid number
 ---@return string filename
-function filename.shorten(winid)
-  local bufid = vim.api.nvim_win_get_buf(winid)
+function filename.shorten(bufid)
   local fname = vim.api.nvim_buf_get_name(bufid)
   return wrap_name(shorten(fname))
 end
 
 ---@param winid number
 ---@return string filename
-function filename.unique(winid)
-  local bufid = vim.api.nvim_win_get_buf(winid)
+function filename.unique(bufid)
   return wrap_name(unique_names:get_name(bufid))
 end
 

--- a/lua/tabby/module/node.lua
+++ b/lua/tabby/module/node.lua
@@ -14,7 +14,7 @@
 ---@field max_width? number maximum width
 ---@field min_width? number minimum width
 
----@alias TabbyClickHandler TabbyClickTab|TabbyCloseTab|TabbyCustomHander
+---@alias TabbyClickHandler TabbyClickTab|TabbyCloseTab|TabbyClickBuf|TabbyCustomHander
 
 ---@class TabbyClickTab
 ---@field [1] "to_tab"
@@ -23,6 +23,10 @@
 ---@class TabbyCloseTab
 ---@field [1] "x_tab"
 ---@field [2] number tabid
+
+---@class TabbyClickBuf
+---@field [1] "to_buf"
+---@field [2] number bufid
 
 ---@class TabbyCustomHander
 ---@field [1] "custom"

--- a/lua/tabby/presets.lua
+++ b/lua/tabby/presets.lua
@@ -34,7 +34,8 @@ end
 
 local function win_label(winid, top)
   local icon = top and '' or ''
-  return string.format(' %s %s ', icon, filename.unique(winid))
+  local bufid = vim.api.nvim_win_get_buf(winid)
+  return string.format(' %s %s ', icon, filename.unique(bufid))
 end
 
 presets.active_wins_at_tail = {
@@ -214,8 +215,9 @@ presets.tab_with_top_win = {
   },
   active_win = {
     label = function(winid)
+      local bufid = vim.api.nvim_win_get_buf(winid)
       return {
-        string.format(' %s ', filename.unique(winid)),
+        string.format(' %s ', filename.unique(bufid)),
         hl = hl_normal,
       }
     end,
@@ -224,8 +226,9 @@ presets.tab_with_top_win = {
   },
   win = {
     label = function(winid)
+      local bufid = vim.api.nvim_win_get_buf(winid)
       return {
-        string.format(' %s ', filename.unique(winid)),
+        string.format(' %s ', filename.unique(bufid)),
         hl = hl_normal,
       }
     end,

--- a/lua/tabby/win.lua
+++ b/lua/tabby/win.lua
@@ -34,7 +34,8 @@ end
 ---@param winid number
 ---@return string bufname
 function win.get_bufname(winid)
-  return buf_name.get(winid)
+  local bufid = vim.api.nvim_win_get_buf(winid)
+  return buf_name.get(bufid)
 end
 
 ---list all win id

--- a/plugin/tabby.vim
+++ b/plugin/tabby.vim
@@ -6,6 +6,13 @@ function! TabbyCustomClickHandler(minwid, clicks, btn, modifiers) abort
         \)
 endfunction
 
+function! TabbyOpenBuffer(minwid, clicks, btn, modifiers) abort
+    " Run the following code only on a single left mouse button click without modifiers pressed
+    if a:clicks == 1 && a:btn is# 'l' && a:modifiers !~# '[^ ]'
+        execute 'buffer' a:minwid
+    endif
+endfunction
+
 function! TabbyTabline() abort
     return luaeval("require'tabby'.update()")
 endfunction


### PR DESCRIPTION
Add `line.bufs().foreach()` function for listing buffers. Works same way as `line.tabs().foreach()` and `line.wins().foreach()`.

1. Only shows listed buffers
2. Makes buffer nodes clickable to switch current window to clicked buffer
3. Adds `buf.is_current()`, `buf.file_icon()` and `buf.name()` analogously to `TabbyWin`

This is useful for people who cycle between buffers in a tab (like myself) using [scope.nvim](https://github.com/tiagovla/scope.nvim) for tab-local buffers.

Relevant issues: #123, [#86 (comment)](https://github.com/nanozuki/tabby.nvim/issues/86#issuecomment-1291046922), #30

BREAKING CHANGE: Changes the API of `tabby.module.filename` and `tabby.feature.buf_name` to use `bufid` instead of `winid`