### PR TITLE
fix: buffer name not updated sometimes

### DIFF
--- a/lua/tabby/feature/buf_name.lua
+++ b/lua/tabby/feature/buf_name.lua
@@ -34,7 +34,7 @@ local resolver = FileNameResolver:new({
   end,
 })
 
-vim.api.nvim_create_autocmd({ 'BufNew', 'BufDelete', 'BufEnter', 'BufLeave' }, {
+vim.api.nvim_create_autocmd({ 'WinNew', 'WinClosed', 'BufWinEnter', 'BufWinLeave', 'BufDelete' }, {
   pattern = '*',
   callback = function()
     resolver:flush()

--- a/lua/tabby/feature/win_name.lua
+++ b/lua/tabby/feature/win_name.lua
@@ -34,7 +34,7 @@ local resolver = FileNameResolver:new({
   end,
 })
 
-vim.api.nvim_create_autocmd({ 'WinNew', 'WinClosed', 'WinLeave', 'WinEnter' }, {
+vim.api.nvim_create_autocmd({ 'WinNew', 'WinClosed', 'WinLeave', 'WinEnter', 'BufWinEnter', 'BufWinLeave', 'BufDelete' }, {
   pattern = '*',
   callback = function()
     resolver:flush()


### PR DESCRIPTION
Fixes #160  where buf_name can be undefined ([no name] shown to the user)
under certain conditions.

Culrpit was commit 96a392b which removed events BufWinEnter,
BufWinLeave, BufDelete. This reintroduces these three events in autocmd
of win_name.

96a392b did not justify the change of events so I'm not confident of my commit. If you don't agree with this commit you can go ahead and edit it.

BTW at first I thought the bug was in lua/tabby/feature/buf_name.lua but this only defines the name of the buffer if you use the API `bufs`. The culprit is in win_name.lua because I use the API win.buf_name()

I don't think buf_name.lua should be impacted by the bug because well \<C-o>/\<C-i> does not change the list of buffers it just changes the buffer inside a window. So only the window API is concerned by this.